### PR TITLE
Only give attributes when entities are created

### DIFF
--- a/configs/randomattributes/settings.cfg
+++ b/configs/randomattributes/settings.cfg
@@ -3,7 +3,6 @@
 // The following settings you can modify with this config are:
 //	- amount: amount of attributes to be given per weapon (convar sm_ra_amount)
 //	- active_only: value 1 forces the 'provide on active' attribute to be given to weapons, making passive attributes these weapons have to be locked as active ones instead (convar sm_ra_activeonly)
-//	- apply_on_weapon_creation: value 1 re-applies attributes when a weapon is created. Mandatory for support to custom gamemodes that give weapons to players mid-round, but comes with the side effect of applying attributes to weapons twice when players spawn [and are given a new weapon entity, which isn't always the case] (convar sm_ra_applyonweaponcreation)
 //	- reroll_on_death (convar sm_ra_rerolldeath): 
 //		- 0: doesn't reroll attributes when a player dies (only when a round starts)
 //		- 1: reroll attributes when a player dies, as long as it's not from a suicide
@@ -25,7 +24,6 @@
 	{
 		"amount"					"-1"
 		"active_only"				"-1"
-		"apply_on_weapon_creation"	"0"
 		"reroll_on_death"			"1"
 		"reroll_on_slot_change"		"0"
 	}
@@ -39,7 +37,6 @@
 		
 		"br_"
 		{
-			"apply_on_weapon_creation"	"1"
 			"reroll_on_slot_change"		"1"
 		}
 		
@@ -50,30 +47,17 @@
 		
 		"gg_"
 		{
-			"apply_on_weapon_creation"	"1"
 			"reroll_on_slot_change"		"1"
-		}
-		
-		"ph_"
-		{
-			"apply_on_weapon_creation"	"1"
 		}
 		
 		"szf_"
 		{
-			"apply_on_weapon_creation"	"1"
 			"reroll_on_slot_change"		"1"
 		}
 		
 		"warioware_"
 		{
-			"apply_on_weapon_creation"	"1"
 			"reroll_on_slot_change"		"1"
-		}
-		
-		"vsh_"
-		{
-			"apply_on_weapon_creation"	"1"
 		}
 	}
 	
@@ -81,7 +65,6 @@
 	{
 		"BomberMod"
 		{
-			"apply_on_weapon_creation"	"1"
 		}
 		
 		"Class Warfare"
@@ -102,7 +85,6 @@
 		
 		"Fortress Royale"
 		{
-			"apply_on_weapon_creation"	"1"
 			"reroll_on_slot_change"		"1"
 		}
 		
@@ -116,13 +98,11 @@
 		
 		"GunGame"
 		{
-			"apply_on_weapon_creation"	"1"
 			"reroll_on_slot_change"		"1"
 		}
 		
 		"Hero Fortress"
 		{
-			"apply_on_weapon_creation"	"1"
 		}
 		
 		"Huntsman Hell"
@@ -135,7 +115,6 @@
 		
 		"MicroTF2"
 		{
-			"apply_on_weapon_creation"	"1"
 			"reroll_on_slot_change"		"1"
 		}
 		
@@ -167,7 +146,6 @@
 		
 		"Super Zombie Fortress"
 		{
-			"apply_on_weapon_creation"	"1"
 			"reroll_on_slot_change"		"1"
 		}
 		
@@ -181,13 +159,11 @@
 		
 		"TF:GO Arena"
 		{
-			"apply_on_weapon_creation"	"1"
 			"reroll_on_slot_change"		"1"
 		}
 		
 		"Versus Saxton Hale"
 		{
-			"apply_on_weapon_creation"	"1"
 		}
 	}
 }

--- a/configs/randomattributes/settings.cfg
+++ b/configs/randomattributes/settings.cfg
@@ -83,9 +83,17 @@
 		{
 		}
 		
+		"Event Map"
+		{
+		}
+		
 		"Fortress Royale"
 		{
 			"reroll_on_slot_change"		"1"
+		}
+		
+		"FortWars"
+		{
 		}
 		
 		"Freeze Tag"
@@ -113,6 +121,10 @@
 		{
 		}
 		
+		"Mann vs. Mann"		// incompatible-ish (pensive emoji)
+		{
+		}
+		
 		"MicroTF2"
 		{
 			"reroll_on_slot_change"		"1"
@@ -127,16 +139,23 @@
 			"reroll_on_death"			"2"
 		}
 		
-		"Prop Hunt"
+		"PropHunt"
 		{
-			"apply_on_weapon_creation"	"1"
 		}
 		
 		"Randomizer"
 		{
 		}
 		
+		"SCP Secret Fortress"
+		{
+		}
+		
 		"Smash Fortress"
+		{
+		}
+		
+		"Stock"
 		{
 		}
 		
@@ -157,9 +176,17 @@
 		{
 		}
 		
-		"TF:GO Arena"
+		"Teufort Turbo"
+		{
+		}
+		
+		"TF:GO"
 		{
 			"reroll_on_slot_change"		"1"
+		}
+		
+		"Turbo Fortress"
+		{
 		}
 		
 		"Versus Saxton Hale"

--- a/scripting/randomattributes.sp
+++ b/scripting/randomattributes.sp
@@ -8,7 +8,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION		"0.5"
+#define PLUGIN_VERSION		"0.6"
 
 #define TF_MAXPLAYERS 		34	//32 clients + 1 for 0/world/console + 1 for replay/SourceTV
 #define MAX_WEAPON_SLOTS 	3

--- a/scripting/randomattributes.sp
+++ b/scripting/randomattributes.sp
@@ -285,7 +285,7 @@ void UpdateClientSlot(int iClient, int iSlot, bool bRefresh = true)
 
 void ApplyToClientSlot(int iClient, int iSlot)
 {
-	if (IsClientInGame(iClient) && IsPlayerAlive(iClient))
+	if (IsClientInGame(iClient))
 	{
 		int iWeapon = GetPlayerWeaponSlot(iClient, iSlot); 
 		ApplyToWeapon(iWeapon, iClient, iSlot);

--- a/scripting/randomattributes.sp
+++ b/scripting/randomattributes.sp
@@ -168,7 +168,6 @@ public void Hook_DroppedWeaponSpawn(int iWeapon)
 {
 	//If attributes are given on weapon creation, attributes of the player will stack with previous attributes this dropped weapon had, and should be disabled in that case
 	TF2Attrib_RemoveAll(iWeapon);
-	TF2Attrib_ClearCache(iWeapon);
 	SDKUnhook(iWeapon, SDKHook_Spawn, Hook_WeaponSpawn);
 }
 

--- a/scripting/randomattributes.sp
+++ b/scripting/randomattributes.sp
@@ -16,7 +16,6 @@
 
 ConVar g_cvEnabled;
 ConVar g_cvActiveOnlyMode;
-ConVar g_cvApplyOnWeaponCreation;
 ConVar g_cvAttributesPerWeapon;
 ConVar g_cvAttributesPerWeaponUpdate;
 ConVar g_cvRerollDeath;
@@ -87,7 +86,7 @@ public void OnClientPutInServer(int iClient)
 
 public void OnEntityCreated(int iEntity, const char[] sClassname)
 {
-	if (!g_cvEnabled.BoolValue || !g_cvApplyOnWeaponCreation.BoolValue)
+	if (!g_cvEnabled.BoolValue)
 		return;
 	
 	if (StrContains(sClassname, "tf_weapon") == 0 || StrContains(sClassname, "tf_wearable") == 0)
@@ -159,7 +158,7 @@ public void Frame_ApplyOnWeaponSpawn(int iWeapon)
 	if (iSlot <= TFWeaponSlot_Melee)
 	{
 		if (g_cvRerollSlot.BoolValue)
-			UpdateClientSlot(iClient, iSlot, false);
+			UpdateClientSlot(iClient, iSlot);
 		
 		ApplyToWeapon(iWeapon, iClient, iSlot);
 	}
@@ -243,14 +242,6 @@ void UpdateClientSlot(int iClient, int iSlot, bool bRefresh = true)
 	g_aClientAttributes[iClient][iSlot].Clear();
 	g_bDisplayedAttributes[iClient][iSlot] = false;
 	
-	if (bRefresh && IsClientInGame(iClient))
-	{
-		int iWeapon = GetPlayerWeaponSlot(iClient, iSlot);
-	
-		if (iWeapon > MaxClients && IsValidEdict(iWeapon))
-			TF2Attrib_RemoveAll(iWeapon);
-	}
-	
 	//If Active Only mode is, heh, active, add the 'provide on active' attribute first
 	if (g_cvActiveOnlyMode.BoolValue)
 	{
@@ -281,6 +272,14 @@ void UpdateClientSlot(int iClient, int iSlot, bool bRefresh = true)
 		}
 		
 		g_aClientAttributes[iClient][iSlot].PushArray(attributeClient);
+	}
+	
+	if (bRefresh && IsClientInGame(iClient))
+	{
+		int iWeapon = GetPlayerWeaponSlot(iClient, iSlot);
+	
+		if (iWeapon > MaxClients && IsValidEdict(iWeapon))
+			TF2Attrib_RemoveAll(iWeapon);
 	}
 }
 
@@ -314,10 +313,10 @@ void ApplyToWeapon(int iWeapon, int iClient, int iSlot)
 	}
 	
 	TF2Attrib_ClearCache(iWeapon);
-	DisplaySlotAttributeNames(iClient, iSlot);
+	DisplaySlotAttributes(iClient, iSlot);
 }
 
-void DisplaySlotAttributeNames(int iClient, int iSlot)
+void DisplaySlotAttributes(int iClient, int iSlot)
 {
 	if (g_bDisplayedAttributes[iClient][iSlot])
 		return;

--- a/scripting/randomattributes/config.sp
+++ b/scripting/randomattributes/config.sp
@@ -131,13 +131,12 @@ void Config_RefreshSettings()
 		return;
 	}
 	
-	int iAmount, iActiveOnly, iApplyOnCreation, iRerollDeath, iRerollSlot;
+	int iAmount, iActiveOnly, iRerollDeath, iRerollSlot;
 	
 	if (kv.JumpToKey("Default"))
 	{
 		iAmount = kv.GetNum("amount", -1);
 		iActiveOnly = kv.GetNum("active_only", -1);
-		iApplyOnCreation = kv.GetNum("apply_on_weapon_creation", -1);
 		iRerollDeath = kv.GetNum("reroll_on_death", -1);
 		iRerollSlot = kv.GetNum("reroll_on_slot_change", -1);
 		
@@ -166,7 +165,6 @@ void Config_RefreshSettings()
 					
 					iAmount = kv.GetNum("amount", iAmount);
 					iActiveOnly = kv.GetNum("active_only", iActiveOnly);
-					iApplyOnCreation = kv.GetNum("apply_on_weapon_creation", iApplyOnCreation);
 					iRerollDeath = kv.GetNum("reroll_on_death", iRerollDeath);
 					iRerollSlot = kv.GetNum("reroll_on_slot_change", iRerollSlot);
 					
@@ -197,7 +195,6 @@ void Config_RefreshSettings()
 				
 				iAmount = kv.GetNum("amount", iAmount);
 				iActiveOnly = kv.GetNum("active_only", iActiveOnly);
-				iApplyOnCreation = kv.GetNum("apply_on_weapon_creation", iApplyOnCreation);
 				iRerollDeath = kv.GetNum("reroll_on_death", iRerollDeath);
 				iRerollSlot = kv.GetNum("reroll_on_slot_change", iRerollSlot);
 				
@@ -218,9 +215,6 @@ void Config_RefreshSettings()
 	
 	if (iActiveOnly >= 0)
 		g_cvActiveOnlyMode.SetInt(iActiveOnly);
-		
-	if (iApplyOnCreation >= 0)
-		g_cvApplyOnWeaponCreation.SetInt(iApplyOnCreation);
 	
 	if (iRerollDeath >= 0)
 		g_cvRerollDeath.SetInt(iRerollDeath);

--- a/scripting/randomattributes/convar.sp
+++ b/scripting/randomattributes/convar.sp
@@ -3,7 +3,6 @@ void ConVar_Init()
 	g_cvEnabled = CreateConVar("sm_ra_enabled", "1", "Is Random Attributes enabled?", _, true, 0.0, true, 1.0);
 	g_cvEnabled.AddChangeHook(ConVar_EnableChanged);
 	g_cvActiveOnlyMode = CreateConVar("sm_ra_activeonly", "0", "Forces the 'provide on active' attribute onto weapons, making (or at least trying its best to make) passive effects only work when a weapon with them is active.", _, true, 0.0, true, 1.0);
-	g_cvApplyOnWeaponCreation = CreateConVar("sm_ra_applyonweaponcreation", "0", "Should attributes be applied when a weapon is created?\n0: No, only apply when inventory is refreshed. Meant for vanilla gamemodes or custom gamemodes that only give weapons upon spawning/inventory update (such as Randomizer)\n1: Yes. This option makes this plugin compatible with custom gamemodes/plugins that can give you custom weapons mid-round (such as Super Zombie Fortress) but has the side effect of applying attributes twice if weapons are given on player spawn", _, true, 0.0, true, 1.0);
 	g_cvAttributesPerWeapon = CreateConVar("sm_ra_amount", "8", "Amount of random attributes to roll per weapon.", _, true, 1.0, true, 20.0);
 	g_cvAttributesPerWeapon.AddChangeHook(ConVar_AmountChanged);
 	g_cvAttributesPerWeaponUpdate = CreateConVar("sm_ra_amountupdate", "0", "Should attributes be rerolled the moment sm_ra_amount is changed?\n0: No, update when it otherwise would\n1: Yes", _, true, 0.0, true, 1.0);

--- a/scripting/randomattributes/event.sp
+++ b/scripting/randomattributes/event.sp
@@ -28,7 +28,13 @@ public Action Event_PlayerDeath(Event event, const char[] sName, bool bDontBroad
 	bool bDeadRinger = (event.GetInt("death_flags") & TF_DEATHFLAG_DEADRINGER) != 0;
 	
 	if (!bDeadRinger && ((0 < iAttacker <= MaxClients && IsClientInGame(iAttacker) && iClient != iAttacker) || g_cvRerollDeath.IntValue >= 2))
-		UpdateClient(iClient);
+	{
+		for (int iSlot = 0; iSlot <= TFWeaponSlot_Melee; iSlot++)
+		{
+			UpdateClientSlot(iClient, iSlot);
+			ApplyToClientSlot(iClient, iSlot);
+		}
+	}
 	
 	return Plugin_Continue;
 }

--- a/scripting/randomattributes/event.sp
+++ b/scripting/randomattributes/event.sp
@@ -1,7 +1,6 @@
 void Event_Init()
 {
 	HookEvent("teamplay_round_win", Event_RoundEnd);
-	HookEvent("post_inventory_application", Event_PlayerInventoryUpdate);
 	HookEvent("player_death", Event_PlayerDeath);
 }
 
@@ -32,36 +31,4 @@ public Action Event_PlayerDeath(Event event, const char[] sName, bool bDontBroad
 		UpdateClient(iClient);
 	
 	return Plugin_Continue;
-}
-
-public Action Event_PlayerInventoryUpdate(Event event, const char[] sName, bool bDontBroadcast)
-{
-	if (!g_cvEnabled.BoolValue)
-		return Plugin_Continue;
-		
-	int iClient = GetClientOfUserId(event.GetInt("userid"));
-	if (TF2_GetClientTeam(iClient) <= TFTeam_Spectator)
-		return Plugin_Continue;
-		
-	if (IsClientInGame(iClient) && IsPlayerAlive(iClient))
-	{
-		for (int iSlot = 0; iSlot <= TFWeaponSlot_Melee; iSlot++)
-		{
-			DataPack data = new DataPack();
-			data.WriteCell(iClient);
-			data.WriteCell(iSlot);
-			data.Reset();
-			RequestFrame(Frame_ApplyToClientSlot, data);	//Applying to the slot instead of to the weapon directly makes this compatible with gamemodes that give different weapons on spawn regardless of weapon creation settings, as they'd change by next frame
-		}
-	}
-	
-	return Plugin_Continue;
-}
-
-void Frame_ApplyToClientSlot(DataPack data)
-{
-	int iClient = data.ReadCell();
-	int iSlot = data.ReadCell();
-	ApplyToClientSlot(iClient, iSlot);
-	delete data;
 }


### PR DESCRIPTION
Turns out adding attributes when a player's stuff is refreshed is not necessary. This is also months old - I don't remember where I stopped but I played around for a little bit and there are no errors showing up, so it's good enough(tm) to me