### PR TITLE
0.8 - SM 1.11 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ Currently deemed incomplete. It works fine, but is a bit rough internally.
 Check [this wiki page](https://github.com/woisalreadytaken/RandomAttributes/wiki/Commands-&-ConVars) for the full list.
 
 ## Thanks To
+* [42](https://github.com/FortyTwoFortyTwo): providing code related to displaying localized strings and letting me borrow him and the Red Sun dev server for occasional private testing.
 * [Mikusch](https://github.com/Mikusch) & [Red Sun Over Paradise](https://redsun.tf): helping me out with public playtesting.
-* [42](https://github.com/FortyTwoFortyTwo): letting me borrow him and the Red Sun dev server for occasional private testing.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Scuffed pseudo-gamemode that gives random attributes to weapons, made in a way t
 Currently deemed incomplete. It works fine, but is a bit rough internally.
 
 ## Dependencies
-- SourceMod 1.10
-- [TF2Attributes](https://forums.alliedmods.net/showthread.php?t=210221)
+- SourceMod 1.10+
+- [nosoop's TF2Attributes fork](https://github.com/nosoop/tf2attributes)
 - [TF2 Econ Data](https://forums.alliedmods.net/showthread.php?t=315011)
 
 ## Commands & ConVars

--- a/scripting/randomattributes.sp
+++ b/scripting/randomattributes.sp
@@ -271,7 +271,7 @@ void UpdateClientSlot(int iClient, int iSlot, bool bRefresh = true)
 		
 		attributeClient.iIndex = attributeConfig.iIndex;
 		
-		//Get the a random value between the max and min values set by the config
+		//Get a random value between the max and min values set by the config
 		switch (attributeConfig.iType)
 		{
 			case ConfigAttributeType_Int: attributeClient.flValue = float(GetRandomInt(RoundToNearest(attributeConfig.flMin), RoundToNearest(attributeConfig.flMax)));

--- a/scripting/randomattributes.sp
+++ b/scripting/randomattributes.sp
@@ -177,7 +177,7 @@ public void Hook_DroppedWeaponSpawn(int iWeapon)
 {
 	//If attributes are given on weapon creation, attributes of the player will stack with previous attributes this dropped weapon had, and should be disabled in that case
 	TF2Attrib_RemoveAll(iWeapon);
-	SDKUnhook(iWeapon, SDKHook_Spawn, Hook_WeaponSpawn);
+	SDKUnhook(iWeapon, SDKHook_Spawn, Hook_DroppedWeaponSpawn);
 }
 
 public void OnPluginEnd()

--- a/scripting/randomattributes.sp
+++ b/scripting/randomattributes.sp
@@ -8,7 +8,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION		"0.7"
+#define PLUGIN_VERSION		"0.8"
 
 #define TF_MAXPLAYERS 		34	//32 clients + 1 for 0/world/console + 1 for replay/SourceTV
 #define MAX_WEAPON_SLOTS 	3

--- a/scripting/randomattributes/command.sp
+++ b/scripting/randomattributes/command.sp
@@ -12,6 +12,8 @@ public Action Command_RefreshAttributesConfig(int iClient, int iArgs)
 	//Server already gets a message about this, so make it show to clients only
 	if (0 < iClient <= MaxClients && IsClientInGame(iClient))
 		ReplyToCommand(iClient, "Refreshed Random Attributes' attributes. It now sees %d attributes.", g_iAttributeAmount);
+		
+	return Plugin_Handled;
 }
 
 public Action Command_RefreshSettingsConfig(int iClient, int iArgs)
@@ -20,10 +22,14 @@ public Action Command_RefreshSettingsConfig(int iClient, int iArgs)
 	
 	if (0 < iClient <= MaxClients && IsClientInGame(iClient))
 		ReplyToCommand(iClient, "Attempted to refresh Random Attributes' map settings config.");
+		
+	return Plugin_Handled;
 }
 
 public Action Command_RefreshConfigs(int iClient, int iArgs)
 {
 	Command_RefreshAttributesConfig(iClient, iArgs);
 	Command_RefreshSettingsConfig(iClient, iArgs);
+	
+	return Plugin_Handled;
 }


### PR DESCRIPTION
Minor update, mainly for doing what's in the title. Changelog:

* Now compiles with no warnings using the SM 1.11 compiler
* Fixes dropped weapon spawns never being unhooked